### PR TITLE
让子命令更易用

### DIFF
--- a/clop_subcommand_test.go
+++ b/clop_subcommand_test.go
@@ -80,6 +80,22 @@ func Test_API_subcommand_SubMain(t *testing.T) {
 // 方法2
 func Test_API_subcommand(t *testing.T) {
 
+	type add struct {
+		All      bool     `clop:"-A; --all" usage:"add changes from all tracked and untracked files"`
+		Force    bool     `clop:"-f; --force" usage:"allow adding otherwise ignored files"`
+		Pathspec []string `clop:"args=pathspec"`
+		isSet    bool
+	}
+
+	type mv struct {
+		Force bool `clop:"-f; --force" usage:"allow adding otherwise ignored files"`
+		isSet bool
+	}
+
+	type git struct {
+		Add add `clop:"subcommand=add" usage:"Add file contents to the index"`
+		Mv  mv  `clop:"subcommand=mv" usage:"Move or rename a file, a directory, or a symlink"`
+	}
 	// 测试正确的情况
 	for _, test := range []testAPI{
 		{

--- a/clop_subcommand_test.go
+++ b/clop_subcommand_test.go
@@ -1,0 +1,123 @@
+package clop
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type add struct {
+	All      bool     `clop:"-A; --all" usage:"add changes from all tracked and untracked files"`
+	Force    bool     `clop:"-f; --force" usage:"allow adding otherwise ignored files"`
+	Pathspec []string `clop:"args=pathspec"`
+	isSet    bool
+}
+
+func (a *add) SubMain() {
+	a.isSet = true
+}
+
+type mv struct {
+	Force bool `clop:"-f; --force" usage:"allow adding otherwise ignored files"`
+	isSet bool
+}
+
+func (m *mv) SubMain() {
+	m.isSet = true
+}
+
+type git struct {
+	Add add `clop:"subcommand=add" usage:"Add file contents to the index"`
+	Mv  mv  `clop:"subcommand=mv" usage:"Move or rename a file, a directory, or a symlink"`
+}
+
+// 方法1
+// 子命令自动调用SubMain接口
+func Test_API_subcommand_SubMain(t *testing.T) {
+
+	// 测试正确的情况
+	for _, test := range []testAPI{
+		{
+			// 测试add子命令
+			func() git {
+				g := git{}
+				p := New([]string{"add", "-Af", "a.txt"}).SetExit(false)
+				err := p.Bind(&g)
+				assert.NoError(t, err)
+				assert.True(t, g.Add.isSet)
+				assert.False(t, g.Mv.isSet)
+				return g
+			}(), git{Add: add{All: true, Force: true, isSet: true, Pathspec: []string{"a.txt"}}}},
+		{
+			// 测试mv子命令
+			func() git {
+				g := git{}
+				p := New([]string{"mv", "-f"}).SetExit(false)
+				err := p.Bind(&g)
+				assert.NoError(t, err)
+				return g
+			}(), git{Mv: mv{Force: true, isSet: true}}},
+		{
+			// 测试-h 输出的Usage
+			func() git {
+				g := git{}
+				p := New([]string{"-h"}).SetExit(false)
+				b := &bytes.Buffer{}
+				p.w = b
+				err := p.Bind(&g)
+				assert.NoError(t, err)
+				assert.True(t, checkUsage(b))
+				os.Stdout.Write(b.Bytes())
+				return g
+			}(), git{Add: add{}}},
+	} {
+		assert.Equal(t, test.need, test.got)
+	}
+}
+
+// 方法2
+func Test_API_subcommand(t *testing.T) {
+
+	// 测试正确的情况
+	for _, test := range []testAPI{
+		{
+			// 测试add子命令
+			func() git {
+				g := git{}
+				p := New([]string{"add", "-Af", "a.txt"}).SetExit(false)
+				err := p.Bind(&g)
+				assert.NoError(t, err)
+				assert.True(t, p.IsSetSubcommand("add"))
+				assert.False(t, p.IsSetSubcommand("mv"))
+				return g
+			}(), git{Add: add{All: true, Force: true, Pathspec: []string{"a.txt"}}}},
+		{
+			// 测试mv子命令
+			func() git {
+				g := git{}
+				p := New([]string{"mv", "-f"}).SetExit(false)
+				err := p.Bind(&g)
+				assert.NoError(t, err)
+				assert.False(t, p.IsSetSubcommand("add"))
+				assert.True(t, p.IsSetSubcommand("mv"))
+				return g
+			}(), git{Mv: mv{Force: true}}},
+		{
+			// 测试-h 输出的Usage
+			func() git {
+				g := git{}
+				p := New([]string{"-h"}).SetExit(false)
+				b := &bytes.Buffer{}
+				p.w = b
+				err := p.Bind(&g)
+				assert.NoError(t, err)
+				assert.True(t, checkUsage(b))
+				os.Stdout.Write(b.Bytes())
+				return g
+			}(), git{Add: add{}}},
+	} {
+		assert.Equal(t, test.need, test.got)
+	}
+}

--- a/clop_test.go
+++ b/clop_test.go
@@ -262,64 +262,6 @@ func Test_API_versionAndAbout(t *testing.T) {
 	}
 }
 
-func Test_API_subcommand(t *testing.T) {
-	type add struct {
-		All      bool     `clop:"-A; --all" usage:"add changes from all tracked and untracked files"`
-		Force    bool     `clop:"-f; --force" usage:"allow adding otherwise ignored files"`
-		Pathspec []string `clop:"args=pathspec"`
-	}
-
-	type mv struct {
-		Force bool `clop:"-f; --force" usage:"allow adding otherwise ignored files"`
-	}
-
-	type git struct {
-		Add add `clop:"subcommand=add" usage:"Add file contents to the index"`
-		Mv  mv  `clop:"subcommand=mv" usage:"Move or rename a file, a directory, or a symlink"`
-	}
-
-	// 测试正确的情况
-	for _, test := range []testAPI{
-		{
-			// 测试add子命令
-			func() git {
-				g := git{}
-				p := New([]string{"add", "-Af", "a.txt"}).SetExit(false)
-				err := p.Bind(&g)
-				assert.NoError(t, err)
-				assert.True(t, p.IsSetSubcommand("add"))
-				assert.False(t, p.IsSetSubcommand("mv"))
-				return g
-			}(), git{Add: add{All: true, Force: true, Pathspec: []string{"a.txt"}}}},
-		{
-			// 测试mv子命令
-			func() git {
-				g := git{}
-				p := New([]string{"mv", "-f"}).SetExit(false)
-				err := p.Bind(&g)
-				assert.NoError(t, err)
-				assert.False(t, p.IsSetSubcommand("add"))
-				assert.True(t, p.IsSetSubcommand("mv"))
-				return g
-			}(), git{Mv: mv{Force: true}}},
-		{
-			// 测试-h 输出的Usage
-			func() git {
-				g := git{}
-				p := New([]string{"-h"}).SetExit(false)
-				b := &bytes.Buffer{}
-				p.w = b
-				err := p.Bind(&g)
-				assert.NoError(t, err)
-				assert.True(t, checkUsage(b))
-				os.Stdout.Write(b.Bytes())
-				return g
-			}(), git{Add: add{}}},
-	} {
-		assert.Equal(t, test.need, test.got)
-	}
-}
-
 // 多行usage消息
 func Test_API_head(t *testing.T) {
 	type head struct {


### PR DESCRIPTION
让子命令更易用. 使用子命令结构体里只实现SubMain会自动帮你调用(当这个子命令在命令行被设置时)
```go
package main

import (
	"fmt"
	"github.com/guonaihong/clop"
)

type add struct {
	All      bool     `clop:"-A; --all" usage:"add changes from all tracked and untracked files"`
	Force    bool     `clop:"-f; --force" usage:"allow adding otherwise ignored files"`
	Pathspec []string `clop:"args=pathspec"`
}

func (a *add) SubMain() {
// 当add子命令被设置时
// clop会自动调用这个函数
}

type mv struct {
	Force bool `clop:"-f; --force" usage:"allow adding otherwise ignored files"`
}

func (m *mv) SubMain() {
// 当mv 子命令被设置时
// clop会自动调用这个函数
}

type git struct {
	Add add `clop:"subcommand=add" usage:"Add file contents to the index"`
	Mv  mv  `clop:"subcommand=mv" usage:"Move or rename a file, a directory, or a symlink"`
}

func main() {
	g := git{}
	clop.Bind(&g)
}